### PR TITLE
Resolves #10

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -1,32 +1,45 @@
 class Api::V1::ItemsController < ApplicationController
-  before_action :set_item, only: %i[show update]
+  before_action :set_item, only: %i[show update destroy]
 
   def index
     @items = Item.all
     json_string = ItemSerializer.new(@items)
     json_response(json_string)
   end
-  
+
   def show
     json_string = ItemSerializer.new(@item)
     json_response(json_string)
   end
-  
+
   def create
-    @item = Item.create!(item_params)
-    json_string = ItemSerializer.new(@item)
-    json_response(json_string, :created)
+    @item = Item.new(item_params)
+    if @item.save
+      json_string = ItemSerializer.new(@item)
+      json_response(json_string, :created)
+    else
+      json_response(@item, :unprocessable_entity)
+    end
   end
 
   def update
-    @item.update!(item_params)
+    if @item.update!(item_params)
+      json_string = ItemSerializer.new(@item)
+      json_response(json_string)
+    else
+      json_response(@item, :not_found)
+    end
+  end
+
+  def destroy
+    @item.destroy
     head :no_content
   end
 
   private
 
   def item_params
-    params.permit(:name, :description, :unit_price, :merchant_id)
+    params.require(:item).permit(:name, :description, :unit_price, :merchant_id)
   end
 
   def set_item

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -7,11 +7,15 @@ module ExceptionHandler
     end
 
     rescue_from ActiveRecord::RecordInvalid do |e|
-      json_response({ message: e.message }, :unprocessable_entity)
+      json_response({ message: e.message }, :not_found)
     end
 
     rescue_from ActiveRecord::RecordNotDestroyed do |e|
       json_response({ errors: e.record.errors }, :unprocessable_entity)
+    end
+
+    rescue_from ActionController::ParameterMissing do |e|
+      json_response({ errors: e.message }, :unprocessable_entity)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :items, only: %i[index show create update] do
+      resources :items do
         scope module: :items do
           resources :merchant, only: [:index]
         end


### PR DESCRIPTION
### RESTful: Destroy an Item
- Created destroy action with route and tests. 
- Updated all previous tests to accept JSON formatted requests. 
- Updated private params methods to require Item for the JSON formatted requests.
- Added error handler for parameter missing exceptions.